### PR TITLE
Only register event handler on initial component mount and not on every component re-render.

### DIFF
--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -19,5 +19,5 @@ export const useClickOutside = (
     return () => {
       document.removeEventListener("click", handleClick);
     };
-  });
+  }, []);
 };


### PR DESCRIPTION
## Prerequisites To Reproduce
1. I added some debugging codes to track the addition and removal of event handler

![image](https://github.com/user-attachments/assets/b661e425-6961-42ad-b37a-80f8878c4784)

2. I registered and logged in to my account

## Steps To Reproduce

1. Click the user icon

![image](https://github.com/user-attachments/assets/e871e52d-04f5-40ca-b43c-e83d21f3a121)

2. Click outside of the dropdown menu, try to do this over and over again and the even handler is registered and removed over and over again.

![image](https://github.com/user-attachments/assets/7b9b00a1-c57e-4b05-a91b-87f94853ba5c)

3. This can also be triggered by clicking the comments icon

![image](https://github.com/user-attachments/assets/629008c3-0aa5-453f-8e5d-192a1449b259)

## Solution

Only register event once on first component mount.

![image](https://github.com/user-attachments/assets/9a554545-6b9c-4c77-8a1b-1876204eb6bd)

Now no matter how many times you click outside the user menu or the comment icon, it won't register and remove the event handler over and over again.

![image](https://github.com/user-attachments/assets/db3622a6-75e5-4521-874f-2f3c1f1f6862)

**Important Note:**

The first event handler register and removal is due to us running in strict mode.

![image](https://github.com/user-attachments/assets/99befd40-d2f3-4dcf-a1a9-5accd11e56d6)



